### PR TITLE
Add `+dotprod` flag to clang++ command

### DIFF
--- a/transformer/Makefile
+++ b/transformer/Makefile
@@ -23,7 +23,7 @@ ifeq ($(shell uname -m),x86_64)
 else ifeq ($(shell uname -p),arm)
 	CXX = /opt/homebrew/opt/llvm/bin/clang++
 	LIB += -L/opt/homebrew/opt/boost/lib
-	CXXFLAGS += -march=native -DQM_ARM -fPIC -march=armv8.2-a
+	CXXFLAGS += -march=native -DQM_ARM -fPIC -march=armv8.2-a+dotprod
 	INCLUDE_DIRS += -I/opt/homebrew/opt/boost/include
 	LIB_SRC += $(wildcard $(LIB_DIR)/neon/*.cc)
 else


### PR DESCRIPTION
Without the flag, using `vdotq_s32` (for SIMD stuff) causes the compilation to fail on M1 Macs